### PR TITLE
First creation of the GeoSPARQL 2.0 SWG Charter from template

### DIFF
--- a/geosparql_2.0_swg_charter/clause_1.adoc
+++ b/geosparql_2.0_swg_charter/clause_1.adoc
@@ -1,0 +1,6 @@
+== Purpose of the Standards Working Group
+
+////
+Proposers will describe the purpose of the Standards Working Group and its overall mission in relation to OGC processes, the OGC standards baseline, and OGC’s business plan.
+////
+

--- a/geosparql_2.0_swg_charter/clause_2.adoc
+++ b/geosparql_2.0_swg_charter/clause_2.adoc
@@ -1,0 +1,5 @@
+== Business Value Proposition
+
+////
+This section provides a statement describing the value of this standards activity in relation to the OGC Membership, the geospatial community, and the wider IT community. This statement can be in terms of the interoperability problem being solved, processing Change requests to meet market (and Member requirements), a policy requirement and/or some other business value proposition. The proposition described in this section does not have to be in economic terms.
+////

--- a/geosparql_2.0_swg_charter/clause_3.adoc
+++ b/geosparql_2.0_swg_charter/clause_3.adoc
@@ -1,0 +1,50 @@
+== Scope of Work
+
+////
+This section describes the scope of work (SOW) for the work of the SWG. There are typically at least three (3) cases that justify the formation of a SWG: A group of members decide to develop a new OGC candidate standard from scratch, there is a draft submission being discussed by OGC members, or there are outstanding Change Requests for an existing OGC standard and a revision is required.
+
+The following describes the characteristics of a SOW for each of these cases.
+
+For a SWG focused on defining and documenting a new OGC candidate standard from “scratch,” the SOW SHALL include a statement of the requirements and use cases for the candidate standard being developed. The SOW SHALL also include a justification statement for developing a new candidate OGC standard. The SOW SHALL also describe how the new candidate standard is related to the existing OGC standards baseline and the OGC Reference Model. The final deliverable of a “from scratch” focused SWG SHALL be a candidate standard ready for submission using the OGC standards process.
+
+For a SWG focused on processing a draft submission such as a specification developed outside the OGC and submitted into the OGC for consideration, the SOW would include evaluation of the submission in terms of the relationship to the existing OGC standards baseline (see section below). The final deliverable of such a SWG SHALL be a candidate standard for consideration by the membership for adoption.
+
+For a SWG focused on revisions to an existing adopted standard, the SOW should include a statement that the SWG will collect all outstanding Change Request Proposals (CRPs), evaluate each of the proposals, and make edits to the standard based on CRPs and related decisions of the SWG membership. The SWG, at their discretion, may also ask the membership for any additional change requests that have not been previous submitted. Again, the final deliverable of a revision focused SWG SHALL be a revision of the candidate standard for consideration by the membership for adoption.
+
+In all cases, the SWG Charter shall provide a basic timeline plan for their activities.
+////
+
+=== Statement of relationship of planned work to the current OGC standards baseline
+
+////
+This section describes the relationship of the proposed standards activity to the existing standards baseline. For the 3 cases:
+If defining a new standard, a statement of the relationship to the existing standards baseline including statements related to overlap (if any) with existing OGC standards functionality, harmonization issues, and so forth.
+
+If processing change requests and performing a revision to an existing standard, a simple statement to this effect shall be made.
+
+If processing a draft submission of a specification developed outside the OGC process, a clear statement of the relationship to the existing standards baseline including statements related to overlap (if any) with existing OGC standards functionality, harmonization issues, and so forth. This information is provided to allow a focus of the discussion on criteria for considering any new solution that may be incompatible with older ones, overlaps existing functionality in the current baseline, and criteria for either deprecating older solutions, or simultaneously endorsing more than one option.
+////
+
+=== What is Out of Scope?
+
+////
+A short description of any activities that will be out of scope for the SWG. For example, a SWG may limit consideration of CRPs after a specified date or milestone.
+////
+
+=== Specific Existing Work Used as Starting Point
+
+////
+This section provides reference information relevant to the work of the SWG. For example, a document reference for a draft submission or a list of CRPs for a SWG focused on revision to an adopted specification.
+////
+
+=== Is This a Persistent SWG
+
+[x] YES
+
+[ ] NO
+
+=== When can the SWG be Inactivated
+
+////
+If this is not a persistent SWG, please define the criteria for determining when the SWG can be inactivated and the project archived. Please note that completion and archiving ensures that all files, wikis, emails, and so forth are archived and available for future viewing and use.
+////

--- a/geosparql_2.0_swg_charter/clause_4.adoc
+++ b/geosparql_2.0_swg_charter/clause_4.adoc
@@ -1,0 +1,20 @@
+== Description of deliverables
+
+////
+This section describes what the deliverables will be for this SWG activity. Deliverables could be a revision to an existing standard, including revisions to schemas. A deliverable could also be a best practices document.
+
+This section also includes a preliminary schedule of activities. For example, an RFC focused SWG schedule would provide a plan and schedule that includes the start date, target date for release of the candidate standard for public review, date for consolidation of comments, date for edits to document based on comments, and a final target date for making a recommendation to the Membership. This information will be made public and will also be used as input to a RoadMap for the document. Therefore, the more detail the better.
+////
+
+=== Initial Deliverables
+
+////
+Describe the initial standard(s) to be developed by the SWG.
+////
+
+=== Additional SWG Tasks
+
+////
+Describe each additional standard to be developed by the SWG as an additional task after the deliverables from the initial charter have been completed. This section is blank in a new charter, then is populated with each task approval request per the OGC TC Policies and Procedures.
+////
+

--- a/geosparql_2.0_swg_charter/clause_6.adoc
+++ b/geosparql_2.0_swg_charter/clause_6.adoc
@@ -1,0 +1,8 @@
+== Anticipated Audience / Participants
+
+////
+Description of the target participants in this SWG. For example, if the SWG were focused on a candidate spatial query language standard: Those involved in the design, development, implementation, or use of elements listed above in "Scope of the Work".  This includes search service providers, prospective users of search services exposed as XML, information architects and bibliographic, metadata, and content provider.
+
+This is not meant as a limiting statement but instead is intended to provide guidance to interested potential participants as to whether they wish to participate in this SWG.
+////
+

--- a/geosparql_2.0_swg_charter/clause_7.adoc
+++ b/geosparql_2.0_swg_charter/clause_7.adoc
@@ -1,0 +1,7 @@
+== Domain Working Group Endorsement
+
+////
+The SWG will list all Domain Working Groups (DWGs) in which the SWG formation was discussed and/or chartered. If a DWG has specifically endorsed the formation of the SWG, then a statement of endorsement should be included.
+////
+
+The Chairs of the Geosemantics Domain Working Group (DWG), Joseph Abhayaratna and Linda van den Brink, do formally endorse the formation of the GeoSPARQL 2.0 Standards Working Group (SWG).

--- a/geosparql_2.0_swg_charter/clause_8.adoc
+++ b/geosparql_2.0_swg_charter/clause_8.adoc
@@ -1,0 +1,52 @@
+== Other informative information about the work of this SWG
+
+=== Collaboration
+
+////
+Describe the work environment of the SWG, including the use of GitHub or GitLab.
+////
+
+=== Similar or Applicable Standards Work (OGC and Elsewhere)
+
+////
+The following standards and projects may be relevant to the SWG's planned work, although none currently provide the functionality anticipated by this committee's deliverables:
+
+OASIS BPEL
+IETF HTTP
+
+The SWG intends to seek and if possible maintain liaison with each of the organizations maintaining the above works.
+////
+
+=== Details of first meeting
+
+////
+Example:
+The first meeting of the SWG will be held by telephone conference call at 10AM EDT on 1 October 2007. Call-in information will be provided to the SWG's e-mail list and on the portal calendar in advance of the meeting.
+////
+
+=== Projected on-going meeting schedule
+
+////
+Example:
+The work of the SWG will be carried out primarily by email and conference calls, possibly every two weeks, with face-to-face meetings perhaps at each of the OGC TC meetings.
+////
+
+=== Supporters of this Charter
+
+The following people support this proposal and are committed to the Charter and projected meeting schedule. These members are known as SWG Founding or Charter members. The charter members agree to the SoW and IPR terms as defined in this charter. The charter members have voting rights beginning the day the SWG is officially formed. Charter Members are shown on the public SWG page. Extend the table as necessary.
+
+|===
+|J. Abhayaratna | PSMA Australia
+|===
+
+=== Conveners
+
+////
+Name of individual(s) who started the SWG process. Could be the lead for an RFC submission, an OGC staff person, or an individual who believes it is time for a revision to an adopted standard.
+////
+
+|===
+|Name |Organization
+|J. Abhayaratna | PSMA Australia
+|===
+

--- a/geosparql_2.0_swg_charter/clause_9.adoc
+++ b/geosparql_2.0_swg_charter/clause_9.adoc
@@ -1,0 +1,5 @@
+== References
+
+////
+Optional list of references.
+////

--- a/geosparql_2.0_swg_charter/swg_charter.adoc
+++ b/geosparql_2.0_swg_charter/swg_charter.adoc
@@ -1,0 +1,100 @@
+:swg-name: GeoSPARQL 2.0 SWG
+:Title: OGC {swg-name} Charter
+:titletext: {Title}
+:doctype: book
+:encoding: utf-8
+:lang: en
+:toc:
+:toc-placement!:
+:toclevels: 4
+:numbered:
+:sectanchors:
+:source-highlighter: pygments
+:submission-date: <yyyy-mm-dd>
+:approval-date: <yyyy-mm-dd>
+:document-number: 20-028
+
+<<<
+[cols = ">",frame = "none",grid = "none"]
+|===
+|{set:cellbgcolor:#FFFFFF}
+|[big]*Open Geospatial Consortium*
+|Submission Date: {submission-date}
+|Approval Date:   {approval-date}
+|Internal reference number of this OGC(R) document:    {document-number}
+|Category: OGC(R) Standards Working Group Charter
+|Authors:   <Name(s) of Editor or Editors>
+|===
+
+[cols = "^", frame = "none"]
+|===
+|[big]*{titletext}*
+|===
+
+[cols = "^", frame = "none", grid = "none"]
+|===
+|*Copyright notice*
+|Copyright (C) 2020 Open Geospatial Consortium
+|To obtain additional rights of use, visit http://www.opengeospatial.org/legal/
+|===
+
+<<<
+
+////
+Version of 2018-12-12
+Some Instructions
+This document is the template to be used for proposing the formation of a new Standards Working Group (SWG).
+
+The first step is to complete the SWG Charter for the proposed new SWG.
+
+The next step is to email the draft SWG charter to the Technical Committee Chair (TCC).  The TCC will review the draft charter and make any necessary comments and provide guidance.
+
+Finally, once the Charter is ready, the SWG charter will be posted to the OGC Pending Documents and the vote process in the Technical Committee Policies and Procedures will start.
+
+Any questions, please contact OGC staff.
+////
+
+To: OGC members & interested parties
+
+A new OGC Standards Working Group is being formed. The OGC members listed below have proposed the OGC {swg-name}.  The SWG proposal provided in this document meets the requirements of the OGC Technical Committee (TC) Policies and Procedures.
+
+The SWG name, statement of purpose, scope, list of deliverables, audience, and language specified in the proposal will constitute the SWG's official charter. Technical discussions may occur no sooner than the SWG's first meeting.
+
+This SWG will operate under the OGC IPR Policy. The eligibility requirements for becoming a participant in the SWG at the first meeting (see details below) are that:
+
+* You must be an employee of an OGC member organization or an individual
+member of OGC;
+
+* The OGC member must have signed the OGC Membership agreement;
+
+* You must notify the SWG chair of your intent to participate to the first meeting. Members may do so by logging onto the OGC Portal and navigating to the Observer page and clicking on the link for the SWG they wish to join and;
+
+* You must attend meetings of the SWG. The first meeting of this SWG is at the time and date fixed below. Attendance may be by teleconference.
+
+Of course, participants also may join the SWG at any time. The OGC and the SWG welcomes all interested parties.
+
+Non-OGC members who wish to participate may contact us about joining the OGC. In addition, the public may access some of the resources maintained for each SWG: the SWG public description, the SWG Charter, Change Requests, and public comments, which will be linked from the SWG’s page.
+
+Please feel free to forward this announcement to any other appropriate lists. The OGC is an open standards organization; we encourage your feedback.
+
+include::clause_1.adoc[]
+
+include::clause_2.adoc[]
+
+include::clause_3.adoc[]
+
+include::clause_4.adoc[]
+
+== IPR Policy for this SWG
+
+[x] RAND-Royalty Free
+
+[ ] RAND for fee
+
+include::clause_6.adoc[]
+
+include::clause_7.adoc[]
+
+include::clause_8.adoc[]
+
+include::clause_9.adoc[]


### PR DESCRIPTION
This change in the creation of the bare bones of the GeoSPARQL 2.0
Standards Working Group Charter from the SWG Charter template
provided by OGC.

The only additions are the document number, and the endorsement of
the Geosemantics DWG Chairs, a Convenor, and the name of the
Convenor in the Charter Members.