### PR TITLE
Update clause_1.adoc

### DIFF
--- a/geosparql_2.0_swg_charter/clause_1.adoc
+++ b/geosparql_2.0_swg_charter/clause_1.adoc
@@ -6,6 +6,6 @@ Proposers will describe the purpose of the Standards Working Group and its overa
 
 The purpose of this SWG is to revise, and likely extend, the GeoSPARQL standard.
 
-Its overall mission is to ensure that the features of GeoSPARQL remain up-to-date with the spatial Semantic Web community whose needs now outstrip the current content of GeoSPARQL.
+Its overall mission is to ensure that the features of GeoSPARQL remain up-to-date with the Semantic Web community whose needs now outstrip the current content of GeoSPARQL.
 
-This revision will likely result in a major update of GeoSPARQL that will be both backwards-compatible with GeoSPARQL and form a new base Semantic Web standard for geospatial users.
+This revision will likely result in a major update of GeoSPARQL that will be both backwards-compatible with GeoSPARQL and form a new base Semantic Web standard for people working with spatial data.


### PR DESCRIPTION
1. Replace ''spatial Semantic Web community" with "Semantic Web community", because I don't think there is specific spatial semweb community. Rather, the semweb community has a whole has to deal with spatial data from time to time. 
2. Replace "spatial users" to say it's about spatial data, and not to exclude those who do not think of themselves as users (but as e.g. provisioners or facilitators)