### PR TITLE
GeoDCAT charter edit

### DIFF
--- a/geodcat_swg_charter/clause_2.adoc
+++ b/geodcat_swg_charter/clause_2.adoc
@@ -3,11 +3,13 @@
 ////
 This section provides a statement describing the value of this standards activity in relation to the OGC Membership, the geospatial community, and the wider IT community. This statement can be in terms of the interoperability problem being solved, processing Change requests to meet market (and Member requirements), a policy requirement and/or some other business value proposition. The proposition described in this section does not have to be in economic terms.
 ////
-DCAT is a widely used metadata standard for datasets and data access services, tpyically within a spatio-temporal context. Some basic temporal and geographic properties have been adopted within the DCAT v2 <<DCAT>> and planned v3 <<DCAT3>>, however these do not address the full range of requirements identified in the <<GeoDCAT-AP>> Discussion paper. 
+DCAT is a widely used W3C vocabulary for describing datasets and data access services, typically within a spatio-temporal context. Some basic temporal and geographic properties have been adopted within the DCAT v2 <<DCAT>> and are planned for v3 <<DCAT3>>, however these properties do not address the full range of requirements identified in the <<GeoDCAT-AP>> Discussion paper. 
 
 The EU references GeoDCAT-AP as a "Good Practice" [at https://inspire.ec.europa.eu/good-practice/geodcat-ap] and notes "A draft for an OGC (Open Geospatial Consortium) Best Practice document is currently under development, and there are discussions to endorse GeoDCAT-AP as an OGC Community Standard."
 
 This charter provides the framework for realization of this goal through development of a GeoDCAT Standard and further refinement of the concept outside the particular constraints of <<DCAT-AP>>. I.e., the work aims to separate a general geospatial profile of DCAT, called "GeoDCAT," out from GeoDCAT-AP; the Europe-specific Application Profile (AP) will not be part of the OGC standardization work.
+
+GeoDCAT will provide a standardized vocabulary and encoding for spatial dataset descriptions and service descriptions (metadata records), based on general Web standards as is described in the Spatial Data on the Web Best Practices. GeoDCAT could in future be used as encoding in catalog API standards such as OGC API Records and STAC.
 
 === Value to the OGC
 To maintain its place as the provider of standards for description and access to spatio-temporal data, the OGC should provide guidance on representation of spatio-temporal concepts in data catalogues. <<GeoDCAT-AP>> is already referenced in the Spatial Data on the Web Best Practice <<SDWBP>>. The SWG will support publishing this as a set of normative resources, with a general profile of DCAT (GeoDCAT) which can be the basis for specialized profiles that are developed outside the SWG (such as GeoDCAT-AP), meeting the specific requirements of the original DCAT-AP context. 

--- a/geodcat_swg_charter/clause_2.adoc
+++ b/geodcat_swg_charter/clause_2.adoc
@@ -9,7 +9,7 @@ The EU references GeoDCAT-AP as a "Good Practice" [at https://inspire.ec.europa.
 
 This charter provides the framework for realization of this goal through development of a GeoDCAT Standard and further refinement of the concept outside the particular constraints of <<DCAT-AP>>. I.e., the work aims to separate a general geospatial profile of DCAT, called "GeoDCAT," out from GeoDCAT-AP; the Europe-specific Application Profile (AP) will not be part of the OGC standardization work.
 
-GeoDCAT will provide a standardized vocabulary and encoding for spatial dataset descriptions and service descriptions (metadata records), based on general Web standards as is described in the Spatial Data on the Web Best Practices. GeoDCAT could in future be used as encoding in catalog API standards such as OGC API Records and STAC.
+GeoDCAT will provide a standardized vocabulary and encoding for spatial dataset descriptions and service descriptions (metadata records), based on general Web standards as are described in the Spatial Data on the Web Best Practices. GeoDCAT could in future be used as encoding in catalog API standards such as OGC API Records and STAC.
 
 === Value to the OGC
 To maintain its place as the provider of standards for description and access to spatio-temporal data, the OGC should provide guidance on representation of spatio-temporal concepts in data catalogues. <<GeoDCAT-AP>> is already referenced in the Spatial Data on the Web Best Practice <<SDWBP>>. The SWG will support publishing this as a set of normative resources, with a general profile of DCAT (GeoDCAT) which can be the basis for specialized profiles that are developed outside the SWG (such as GeoDCAT-AP), meeting the specific requirements of the original DCAT-AP context. 

--- a/geodcat_swg_charter/clause_3.adoc
+++ b/geodcat_swg_charter/clause_3.adoc
@@ -18,7 +18,7 @@ The primary goal of this SWG's work is to define GeoDCAT as a set of modules or 
 
 The SWG will look into the relationships with other relevant standards and possibly provide conceptual mappings. Part of the GeoDCAT vocabulary deliverable will be the relationship with other relevant standards, e.g., GeoDCAT-AP, ISO 19115, OGC API Records, STAC, GeoSPARQL, Dublin Core, schema.org, and others. 
 
-NOTE each of the standards mentioned above have their own lifecycle and governance. It is up to the SWG to decide if created mappings between GeoDCAT and these standards will be kept up to date. 
+**__NOTE:__** __Each of the standards mentioned above has its own lifecycle and governance. It is up to the SWG to decide whether mappings created between GeoDCAT and these standards will be kept up to date.__
 
 Future activities will include definition of additional specialized profiles as required and requested by specific applications domains (via OGC Domain Working Group inputs).
 

--- a/geodcat_swg_charter/clause_3.adoc
+++ b/geodcat_swg_charter/clause_3.adoc
@@ -16,7 +16,7 @@ The SWG will assess, based on the review of best practices and examples of use, 
 
 The primary goal of this SWG's work is to define GeoDCAT as a set of modules or building blocks.
 
-The SWG will look into the relationships with other relevant standards and possibly provide conceptual mappings. Part of the GeoDCAT vocabulary deliverable will be the relationship with other relevant standards e.g., GeoDCAT-AP, ISO 19115, OGC API Records, STAC, GeoSPARQL, Dublin Core, schema.org, and others. 
+The SWG will look into the relationships with other relevant standards and possibly provide conceptual mappings. Part of the GeoDCAT vocabulary deliverable will be the relationship with other relevant standards, e.g., GeoDCAT-AP, ISO 19115, OGC API Records, STAC, GeoSPARQL, Dublin Core, schema.org, and others. 
 
 NOTE each of the standards mentioned above have their own lifecycle and governance. It is up to the SWG to decide if created mappings between GeoDCAT and these standards will be kept up to date. 
 

--- a/geodcat_swg_charter/clause_3.adoc
+++ b/geodcat_swg_charter/clause_3.adoc
@@ -14,7 +14,7 @@ The initial activities will be to:
 
 The SWG will assess, based on the review of best practices and examples of use, if there is sufficient motivation to create GeoDCAT as an OGC Standard. 
 
-The SWG aims to set up GeoDCAT in a modularized way. 
+The primary goal of this SWG's work is to define GeoDCAT as a set of modules or building blocks.
 
 The SWG will look into the relationships with other relevant standards and possibly provide conceptual mappings. Part of the GeoDCAT vocabulary deliverable will be the relationship with other relevant standards e.g., GeoDCAT-AP, ISO 19115, OGC API Records, STAC, GeoSPARQL, Dublin Core, schema.org, and others. 
 


### PR DESCRIPTION
Charter edits in response to comments: 

Nadine/Scott : 
> elaborate a bit more on what GeoDCAT does and will do and drop a good reference to the Spatial Data on the Web Best Practice

In response to this I added the following to clause 2: 

> GeoDCAT will provide a standardized vocabulary and encoding for spatial dataset descriptions and service descriptions (metadata records), based on general Web standards as is described in the Spatial Data on the Web Best Practices. GeoDCAT could in future be used as encoding in catalog API standards such as OGC API Records and STAC.

Carl Reed: several editorial remarks 

This PR includes a few edits in clause 2 and 3 to address these editorials.

Keeping this PR open for now, in case we need to take care of other review comments.